### PR TITLE
bin/assignment_precheck: change default_branch from master to main

### DIFF
--- a/bin/assignment_precheck
+++ b/bin/assignment_precheck
@@ -26,7 +26,7 @@
 cmd_dir=$(dirname "$0") || exit 1
 source "$cmd_dir/utilities" || exit 1
 
-default_branch=master
+default_branch=main
 
 usage()
 {


### PR DESCRIPTION
Github classrooms create the default branch as main instead of master. A small nit, for having to specify the "-b main" flag when using assignment_precheck command